### PR TITLE
Fix/sorting on wp menu items

### DIFF
--- a/spec/features/support/ui_select.rb
+++ b/spec/features/support/ui_select.rb
@@ -31,7 +31,11 @@ require 'features/work_packages/details/inplace_editor/shared_contexts'
 shared_context 'ui-select helpers' do
   include_context 'maximized window'
   def ui_select_choose(select2_element, option_name)
+    # Open the element
     select2_element.find('.select2-choice').click
+    # Insert the text to find
+    select2_element.find('.select2-search input').set(option_name)
+    # click the element to select it
     select2_element.find('ul.select2-result-single li', text: option_name).click
   end
 end

--- a/spec/features/support/ui_select.rb
+++ b/spec/features/support/ui_select.rb
@@ -26,10 +26,7 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-require 'features/work_packages/details/inplace_editor/shared_contexts'
-
 shared_context 'ui-select helpers' do
-  include_context 'maximized window'
   def ui_select_choose(select2_element, option_name)
     # Open the element
     select2_element.find('.select2-choice').click


### PR DESCRIPTION
This prevents the problem of the ui-select option not being visible by inserting the text into the ui-select input first. Doing so reduces the number of items in the list. Select then becomes easy.